### PR TITLE
タブグループを右クリックするとメニューが表示できるようにした

### DIFF
--- a/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx
+++ b/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx
@@ -17,6 +17,10 @@ interface Props {
   updatedTabGroupList: Function
   // タブの編集モードを更新するメソッド
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>
+  // オプションの状態
+  open: boolean
+  anchorEl: HTMLElement | null
+  setAnchorEl: Function
 }
 
 const StyledMenu = styled((props: MenuProps) => (
@@ -63,15 +67,12 @@ const StyledMenu = styled((props: MenuProps) => (
 }))
 
 export default function ActiveTabGroupOption(props: Props): JSX.Element {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl)
-
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
-    setAnchorEl(event.currentTarget)
+    props.setAnchorEl(event.currentTarget)
   }
 
   const handleClose = (): void => {
-    setAnchorEl(null)
+    props.setAnchorEl(null)
   }
 
   const runEditGroupTabs = (): void => {
@@ -102,8 +103,8 @@ export default function ActiveTabGroupOption(props: Props): JSX.Element {
       <IconButton
         aria-label="more"
         id="demo-customized-button"
-        aria-controls={open ? 'long-menu' : undefined}
-        aria-expanded={open ? 'true' : undefined}
+        aria-controls={props.open ? 'long-menu' : undefined}
+        aria-expanded={props.open ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -114,8 +115,8 @@ export default function ActiveTabGroupOption(props: Props): JSX.Element {
         MenuListProps={{
           'aria-labelledby': 'demo-customized-button'
         }}
-        anchorEl={anchorEl}
-        open={open}
+        anchorEl={props.anchorEl}
+        open={props.open}
         onClose={handleClose}
       >
         <MenuItem onClick={runEditGroupTabs} disableRipple>

--- a/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx
+++ b/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx
@@ -24,6 +24,24 @@ interface Props {
 }
 
 export default function DisplayActiveTabGroup(props: Props): JSX.Element {
+  // タブグループメニュを管理
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+
+  const handleTabGroupItemClick = (
+    e: React.MouseEvent<HTMLDivElement, MouseEvent>,
+    isRight: boolean,
+    tabGroupId: number,
+    collapsed: boolean
+  ): void => {
+    e.preventDefault()
+    if (isRight) {
+      setAnchorEl(e.currentTarget)
+    } else {
+      runUpdateTabGroupCollapsed(tabGroupId, collapsed)
+    }
+  }
+
   const runUpdateTabGroupCollapsed = (
     tabGroupId: number,
     collapsed: boolean
@@ -42,8 +60,11 @@ export default function DisplayActiveTabGroup(props: Props): JSX.Element {
     <ListItem>
       <ListItemButton
         sx={{ pl: 4 }}
-        onClick={() => {
-          runUpdateTabGroupCollapsed(props.id, props.collapsed)
+        onClick={(e) => {
+          handleTabGroupItemClick(e, false, props.id, props.collapsed)
+        }}
+        onContextMenu={(e) => {
+          handleTabGroupItemClick(e, true, props.id, props.collapsed)
         }}
       >
         <ListItemText>{props.title}</ListItemText>
@@ -59,6 +80,9 @@ export default function DisplayActiveTabGroup(props: Props): JSX.Element {
         tabGroupId={props.id}
         updatedTabGroupList={props.updatedTabGroupList}
         setEditMode={props.setEditMode}
+        open={open}
+        anchorEl={anchorEl}
+        setAnchorEl={setAnchorEl}
       />
     </ListItem>
   )

--- a/src/components/molecules/settingItems/settingsDescription.tsx
+++ b/src/components/molecules/settingItems/settingsDescription.tsx
@@ -1,60 +1,58 @@
 import React from 'react'
-import { makeStyles } from '@material-ui/core/styles';
-import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import Button from '@material-ui/core/Button';
-import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+import Typography from '@material-ui/core/Typography'
 
 const useStyles = makeStyles({
-    root: {
-        minWidth: 275,
-    },
-    bullet: {
-        display: 'inline-block',
-        margin: '0 2px',
-        transform: 'scale(0.8)',
-    },
-    title: {
-        fontSize: 16,
-    },
-    pos: {
-        fontSize: 14,
-        marginBottom: 12,
-    },
-});
+  root: {
+    minWidth: 275
+  },
+  bullet: {
+    display: 'inline-block',
+    margin: '0 2px',
+    transform: 'scale(0.8)'
+  },
+  title: {
+    fontSize: 16
+  },
+  pos: {
+    fontSize: 14,
+    marginBottom: 12
+  }
+})
 
 export function SettingsDescription(): JSX.Element {
-    const classes = useStyles();
+  const classes = useStyles()
 
-    return (
-        <Card className={classes.root} variant="outlined">
-            <CardContent>
-                <Typography className={classes.title} color="initial" gutterBottom>
-                    GroupMode: Default
-                </Typography>
-                <Typography className={classes.pos} color="textSecondary">
-                    グループ化されていないタブを対象に開いているタブ全てを一つにグループ化する
-                </Typography>
+  return (
+    <Card className={classes.root} variant="outlined">
+      <CardContent>
+        <Typography className={classes.title} color="initial" gutterBottom>
+          GroupMode: Default
+        </Typography>
+        <Typography className={classes.pos} color="textSecondary">
+          グループ化されていないタブを対象に開いているタブ全てを一つにグループ化する
+        </Typography>
 
-                <Typography className={classes.title} gutterBottom>
-                    GroupMode: Domain
-                </Typography>
-                <Typography className={classes.pos} color="textSecondary">
-                    ドメインごとにグループ化する
-                    <br />
-                    ※サブドメインは無視する
-                </Typography>
+        <Typography className={classes.title} gutterBottom>
+          GroupMode: Domain
+        </Typography>
+        <Typography className={classes.pos} color="textSecondary">
+          ドメインごとにグループ化する
+          <br />
+          ※サブドメインは無視する
+        </Typography>
 
-                <Typography className={classes.title} gutterBottom>
-                    GroupMode: Custom
-                </Typography>
-                <Typography className={classes.pos} color="textSecondary">
-                    「RULE」タブの内容に従ってグループ化する
-                    <br />
-                    ※サブドメインは無視する
-                </Typography>
-            </CardContent>
-        </Card>
-    );
+        <Typography className={classes.title} gutterBottom>
+          GroupMode: Custom
+        </Typography>
+        <Typography className={classes.pos} color="textSecondary">
+          「RULE」タブの内容に従ってグループ化する
+          <br />
+          ※サブドメインは無視する
+        </Typography>
+      </CardContent>
+    </Card>
+  )
 }


### PR DESCRIPTION
diff --git a/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx b/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx index ef7d9c8..6d46a5d 100644
--- a/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx +++ b/src/components/molecules/activeTabGroupItem/activeTabGroupOption.tsx @@ -17,6 +17,10 @@ interface Props {
   updatedTabGroupList: Function
   // タブの編集モードを更新するメソッド
   setEditMode: React.Dispatch<React.SetStateAction<boolean>>
+  // オプションの状態
+  open: boolean
+  anchorEl: HTMLElement | null
+  setAnchorEl: Function }

 const StyledMenu = styled((props: MenuProps) => (
@@ -63,15 +67,12 @@ const StyledMenu = styled((props: MenuProps) => (
 }))

 export default function ActiveTabGroupOption(props: Props): JSX.Element {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const open = Boolean(anchorEl) -
   const handleClick = (event: React.MouseEvent<HTMLElement>): void => {
-    setAnchorEl(event.currentTarget)
+    props.setAnchorEl(event.currentTarget)
   }

   const handleClose = (): void => {
-    setAnchorEl(null)
+    props.setAnchorEl(null)
   }

   const runEditGroupTabs = (): void => { @@ -102,8 +103,8 @@ export default function ActiveTabGroupOption(props: Props): JSX.Element {
       <IconButton
         aria-label="more"
         id="demo-customized-button"
-        aria-controls={open ? 'long-menu' : undefined}
-        aria-expanded={open ? 'true' : undefined}
+        aria-controls={props.open ? 'long-menu' : undefined}
+        aria-expanded={props.open ? 'true' : undefined}
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -114,8 +115,8 @@ export default function ActiveTabGroupOption(props: Props): JSX.Element {
         MenuListProps={{
           'aria-labelledby': 'demo-customized-button'
         }}
-        anchorEl={anchorEl}
-        open={open}
+        anchorEl={props.anchorEl}
+        open={props.open}
         onClose={handleClose}
       >
         <MenuItem onClick={runEditGroupTabs} disableRipple>
diff --git a/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx b/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx index 8f9908e..94575f6 100644
--- a/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx +++ b/src/components/molecules/activeTabGroupItem/displayActiveTabGroup.tsx @@ -24,6 +24,23 @@ interface Props {
 }

 export default function DisplayActiveTabGroup(props: Props): JSX.Element {
+
+  // オプション
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl) +
+
+  const handleTabGroupItemClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, isRight: boolean, tabGroupId: number, collapsed: boolean): void => {
+    e.preventDefault();
+    if (isRight) {
+      setAnchorEl(e.currentTarget)
+    }
+    else {
+      runUpdateTabGroupCollapsed(tabGroupId, collapsed)
+    }
+
+  }
+
   const runUpdateTabGroupCollapsed = (
     tabGroupId: number,
     collapsed: boolean
@@ -42,9 +59,8 @@ export default function DisplayActiveTabGroup(props: Props): JSX.Element {
     <ListItem>
       <ListItemButton
         sx={{ pl: 4 }}
-        onClick={() => {
-          runUpdateTabGroupCollapsed(props.id, props.collapsed)
-        }}
+        onClick={(e) => { handleTabGroupItemClick(e, false, props.id, props.collapsed) }}
+        onContextMenu={(e) => { handleTabGroupItemClick(e, true, props.id, props.collapsed) }}
       >
         <ListItemText>{props.title}</ListItemText>
       </ListItemButton>
@@ -59,7 +75,10 @@ export default function DisplayActiveTabGroup(props: Props): JSX.Element {
         tabGroupId={props.id}
         updatedTabGroupList={props.updatedTabGroupList}
         setEditMode={props.setEditMode}
+        open={open}
+        anchorEl={anchorEl}
+        setAnchorEl={setAnchorEl}
       />
-    </ListItem>
+    </ListItem >
   )
 }